### PR TITLE
wrong option use -t or --tunnel

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ Run the websocket tunnel server at port 8080 on all interfaces:
 
 Run the websocket tunnel client:
 
-    wstunnel -tunnel 33:2.2.2.2:33 ws://host:8080
+    wstunnel -t 33:2.2.2.2:33 ws://host:8080
 
 In the above example, client picks the final tunnel destination, similar to ssh tunnel.  Alternatively for security
 reason, you can lock tunnel destination on the server end, example:


### PR DESCRIPTION
this command
wstunnel -tunnel 33:2.2.2.2:33 ws://host:8080
give this error:

C:\Users\user1\AppData\Roaming\npm\node_modules\wstunnel\bin\wstunnel.js:34
        toks = argv.t.split(":");
                      ^

TypeError: argv.t.split is not a function
    at C:\Users\user1\AppData\Roaming\npm\node_modules\wstunnel\bin\wstunnel.js:34:23
    at C:\Users\user1\AppData\Roaming\npm\node_modules\wstunnel\node_modules\machine-uuid\index.js:32:18
    at C:\Users\user1\AppData\Roaming\npm\node_modules\wstunnel\node_modules\machine-uuid\index.js:86:18
    at ChildProcess.exithandler (child_process.js:197:7)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:191:7)
    at maybeClose (internal/child_process.js:877:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:226:5)