### PR TITLE
Don't include insecure -c flag in suggested commands.

### DIFF
--- a/bin/wstunnel.js
+++ b/bin/wstunnel.js
@@ -23,7 +23,7 @@ If client run:
 In client mode, you can bind stdio to the tunnel by running:
  wstunnel -t stdio:host:port ws[s]://wshost:wsport
 This allows the command to be used as ssh proxy:
- ssh -o ProxyCommand="wstunnel -c -t stdio:%h:%p https://wstserver" user@sshdestination
+ ssh -o ProxyCommand="wstunnel -t stdio:%h:%p https://wstserver" user@sshdestination
 Above command will ssh to "user@sshdestination" via the wstunnel server at "https://wstserver"
 
 `

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ A public docker image "mhzed/wstunnel" is now available.
 Example:
 ```
 # run as client to connect to wss://server.com, tunnel localhost:2244 to target.ip:22 
-docker run --rm -d -p 2244:2244 mhzed/wstunnel -c -t 0.0.0.0:2244:target.ip:22 wss://server.com
+docker run --rm -d -p 2244:2244 mhzed/wstunnel -t 0.0.0.0:2244:target.ip:22 wss://server.com
 ```
 
 Notice "-t 0.0.0.0:2244..." above.  By default wstunnel binds to localhost which is unreachable inside a docker container, so make sure to specify "0.0.0.0" to bind to all local IPs.
@@ -100,7 +100,7 @@ Then on client:
 To use as a proxy for "ssh", run:
 
 ```
-ssh -o ProxyCommand="wstunnel -c -t stdio:%h:%p https://server" user@sshDestination
+ssh -o ProxyCommand="wstunnel -t stdio:%h:%p https://server" user@sshDestination
 ```
 
 Above command will ssh to "user@sshDestination" via wstunnel server at "https://server".


### PR DESCRIPTION
I just realized that I've been sending passwords (via basic authentication) over a channel that was vulnerable to MITM attacks for at least a year, because I copy-pasted from the readme and didn't investigate what all the flags did. (Fortunately in my case the other end of the tunnel is an SSH server, so there's not a whole lot you can do even with the password, but still.)

Here's a PR to keep other people from making the same mistake I did; if they *do* need to ignore cert warnings they can add the flag after getting an error, which is much better than it silently failing open.