### PR TITLE
$ npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -384,9 +384,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -865,7 +865,8 @@
     "prettier": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
-      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg=="
+      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
+      "dev": true
     },
     "promise.allsettled": {
       "version": "1.0.2",
@@ -1032,9 +1033,9 @@
       }
     },
     "underscore": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-      "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
     "uuid": {
       "version": "3.3.2",
@@ -1152,9 +1153,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
     },
     "yaeti": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "optimist": "0.3.5",
     "phuture": "^1.0.7",
     "socks-proxy-agent": "^4.0.1",
-    "underscore": "1.4.4",
+    "underscore": "^1.13.1",
     "websocket": "^1.0.28"
   },
   "devDependencies": {


### PR DESCRIPTION
When I install node libraries by `npm install`, I found it.

```
 npm install

> websocket@1.0.28 install /.../mhzed/wstunnel/node_modules/websocket
> (node-gyp rebuild 2> builderror.log) || (exit 0)

added 167 packages from 88 contributors and audited 167 packages in 4.509s

28 packages are looking for funding
  run `npm fund` for details

found 4 vulnerabilities (1 moderate, 3 high)
  run `npm audit fix` to fix them, or `npm audit` for details
```

After I updated by `npm audit fix`, I test to launch tunnel server and tunnel client.

```
$ node ./bin/wstt.js -s 0.0.0.0:3330
(no error)

$ node ./bin/wstt.js -t 3331 ws://0.0.0.0:3330
(no error)
```