### PR TITLE
Allow all SOCKS proxy versions supported by SocksProxyAgent

### DIFF
--- a/bin/wstunnel.js
+++ b/bin/wstunnel.js
@@ -83,7 +83,7 @@ module.exports = (Server, Client) => {
 
       if (argv.proxy) {
         const conf = urlParse(argv.proxy);
-        if (conf.protocol === 'socks:') {
+        if (['socks4:', 'socks4a:', 'socks5:', 'socks:', 'socks5h:'].includes(conf.protocol)) {
           client.setAgentMaker(
             (c) => new SocksProxyAgent(Object.assign({}, c, conf))
           );


### PR DESCRIPTION
Versions added according to the source file of socks-proxy-agent: https://github.com/TooTallNate/node-socks-proxy-agent/blob/master/src/agent.ts